### PR TITLE
Prevent delete on esc for empty val.

### DIFF
--- a/examples/jquery/js/app.js
+++ b/examples/jquery/js/app.js
@@ -173,7 +173,7 @@ jQuery(function ($) {
 			var $el = $(el);
 			var val = $el.val().trim();
 
-			if (!val) {
+			if (val !== '' && !val) {
 				this.destroy(e);
 				return;
 			}


### PR DESCRIPTION
Problem: When trying to call the update method, if the val is an empty string the first if statement will execute calling the destroy method.
Solution: Check for empty strings.